### PR TITLE
Fixes for LiveTV

### DIFF
--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -777,7 +777,7 @@
 						<height>146</height>
 						<aspectratio>stretch</aspectratio>
 						<colordiffuse>66FFFFFF</colordiffuse>
-                        <animation effect="zoom" start="100" end="110,130" time="0" condition="true" center="auto">Conditional</animation>
+                        <animation effect="zoom" start="100" end="110,135" time="0" condition="true" center="auto">Conditional</animation>
 						<texture border="40">buttons/roundedbutton-nofocus.png</texture>
 					</control>
 					<control type="label">
@@ -809,14 +809,14 @@
 						<control type="label">
 							<width>420</width>
 							<height>30</height>
-							<font>Font_Reg30</font>
+							<font>Font_Reg29</font>
 							<textcolor>grey2</textcolor>
 							<selectedcolor>selected</selectedcolor>
 							<align>left</align>
 							<label>$INFO[ListItem.Title]</label>
 						</control>
 						<control type="progress">
-							<top>37</top>
+							<top>36</top>
 							<width>408</width>
 							<height>6</height>
 							<info>ListItem.Progress</info>
@@ -831,9 +831,9 @@
 							<top>44</top>
 							<width>400</width>
 							<height>30</height>
-							<font>Font_Reg29</font>
+							<font>Font_Reg28</font>
 							<align>left</align>
-							<textcolor>grey3</textcolor>
+							<textcolor>grey2</textcolor>
 							<selectedcolor>grey2</selectedcolor>
 							<label>$LOCALIZE[19031]: $INFO[ListItem.NextTitle]</label>
 							<visible>true</visible>
@@ -847,8 +847,8 @@
 						<width>434</width>
 						<height>146</height>
 						<aspectratio>stretch</aspectratio>
-						<colordiffuse>BFFFFFFF</colordiffuse>
-                        <animation effect="zoom" start="100" end="110,130" time="0" condition="true" center="auto">Conditional</animation>
+                        <animation effect="zoom" start="100" end="110,135" time="0" condition="true" center="auto">Conditional</animation>
+						<animation effect="fade" start="10" end="50" time="300" easing="in">Focus</animation>
 						<texture colordiffuse="$VAR[AreaColorVar]" border="40">buttons/roundedbutton-focus.png</texture>
 					</control>
 					<control type="image">
@@ -879,19 +879,19 @@
 						<control type="label">
 							<width>420</width>
 							<height>30</height>
-							<font>Font_Reg30</font>
+							<font>Font_Reg29</font>
 							<selectedcolor>selected</selectedcolor>
 							<align>left</align>
 							<label>$INFO[ListItem.Title]</label>
 						</control>
 						<control type="progress">
-							<top>37</top>
+							<top>36</top>
 							<width>408</width>
 							<height>6</height>
 							<info>ListItem.Progress</info>
 							<visible>!IsEmpty(ListItem.Title)</visible>
 							<midtexture colordiffuse="$VAR[FontColorVar]">new_pvr/texturebg_white.png</midtexture>
-							<texturebg colordiffuse="white3">new_pvr/texturebg.png</texturebg>
+							<texturebg>new_pvr/texturebg.png</texturebg>
 							<lefttexture>-</lefttexture>
 							<righttexture>-</righttexture>
 						</control>
@@ -900,9 +900,9 @@
 							<top>44</top>
 							<width>400</width>
 							<height>30</height>
-							<font>Font_Reg29</font>
+							<font>Font_Reg28</font>
 							<align>left</align>
-							<textcolor>grey2</textcolor>
+							<textcolor>grey</textcolor>
 							<selectedcolor>grey</selectedcolor>
 							<label>$LOCALIZE[19031]: $INFO[ListItem.NextTitle]</label>
 						</control>
@@ -911,11 +911,11 @@
 			</control>
 			<control type="scrollbar" id="60">
 				<left>1842</left>
-				<top>0</top>
+				<top>95</top>
 				<width>46</width>
 				<height>625</height>
 				<onleft>52</onleft>
-				<onleft>52</onleft>
+				<onright>52</onright>
 				<ondown>60</ondown>
 				<onup>60</onup>
 				<showonepage>false</showonepage>

--- a/1080i/MyPVRGuide.xml
+++ b/1080i/MyPVRGuide.xml
@@ -51,8 +51,7 @@
                 <progresstexture border="0,60,18,14">new_pvr/PVR-EpgProgressIndicator2.png</progresstexture>
                 <rulerlayout height="45" width="1400">
                     <control type="label">
-                        <left>0</left>
-                        <top>-2</top>
+                        <top>2</top>
                         <width>500</width>
                         <height>45</height>
                         <font>Font_Reg18</font>
@@ -299,7 +298,6 @@
                 <height>227</height>
                 <width>400</width>
                 <control type="group">
-                    <visible>!Player.HasVideo</visible>
                     <control type="image">
                         <left>100</left>
                         <top>35</top>
@@ -567,7 +565,6 @@
                 <height>227</height>
                 <width>400</width>
                 <control type="group">
-                    <visible>!Player.HasVideo</visible>
                     <control type="image">
                         <left>100</left>
                         <top>35</top>
@@ -958,6 +955,7 @@
                     <viewtype label="19029">list</viewtype>
                     <pagecontrol>75</pagecontrol>
                     <scrolltime>200</scrolltime>
+					<visible>Player.HasVideo</visible>
                     <itemlayout height="60">
                         <control type="image">
                             <left>-45</left>

--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -1373,7 +1373,7 @@
         <value condition="Window.IsActive(weather)">$LOCALIZE[8]</value>
         <value condition="Window.IsActive(pictures)">$LOCALIZE[1213]</value>
         <value condition="Window.IsActive(filemanager)">$LOCALIZE[10003]</value>
-        <value condition="Window.IsActive(PVR)">$LOCALIZE[31017]$INFO[Control.GetLabel(29), / ]$INFO[Control.GetLabel(30), / ]</value>
+        <value condition="Window.IsActive(TVChannels) | Window.IsActive(RadioChannels) | Window.IsActive(TVGuide) | Window.IsActive(RadioGuide) | Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings) | Window.IsActive(TVTimers) | Window.IsActive(RadioTimers) | Window.IsActive(TVSearch) | Window.IsActive(RadioSearch)">$LOCALIZE[31017]$INFO[Control.GetLabel(29), / ]$INFO[Control.GetLabel(30), / ]</value>
         <value condition="Window.IsActive(script-NextAired-TVGuide.xml)">$LOCALIZE[31290]</value>
         <value condition="Window.IsActive(script-globalsearch-main.xml)">$LOCALIZE[283]</value>
         <value condition="Window.IsActive(script-Rom_Collection_Browser-main.xml)">Rom Collection Browser $INFO[ListItem.Property(romcollection), / ]</value>


### PR DESCRIPTION
Fixed breadcrumbs for LiveTV, correct path is now shown in Guide and other views.
Fixed channel logo display in Guide while watching a channel.
Minor changes to display and animation in Channel-Wall view.
