### PR TITLE
Invert condition for UseCaseCD property

### DIFF
--- a/1080i/custom_1126_ViewtypeSettings.xml
+++ b/1080i/custom_1126_ViewtypeSettings.xml
@@ -350,7 +350,7 @@
                     <label>$LOCALIZE[31282]</label>
                     <include>ViewtypeSettingsButton</include>
                     <onclick>Skin.ToggleSetting(usecasescd)</onclick>
-                    <selected>!Skin.HasSetting(usecasescd)</selected>
+                    <selected>Skin.HasSetting(usecasescd)</selected>
                     <visible>Stringcompare(Window(home).Property(actualViewtype),ShowcaseSquare) + Container.Content(albums)</visible>
                 </control>
                 <control type="radiobutton" id="1651">


### PR DESCRIPTION
As $LOCALIZE[31282]="Clear Case", this property should be set to True when you select it.
Actually, when option is selected, Clear cases are not displayed ;)